### PR TITLE
Issue #72: Fixed interval problems

### DIFF
--- a/flask_praetorian/base.py
+++ b/flask_praetorian/base.py
@@ -96,12 +96,12 @@ class Praetorian:
         self.encode_algorithm = app.config.get(
             'JWT_ALGORITHM', DEFAULT_JWT_ALGORITHM,
         )
-        self.access_lifespan = app.config.get(
+        self.access_lifespan = pendulum.interval(**app.config.get(
             'JWT_ACCESS_LIFESPAN', DEFAULT_JWT_ACCESS_LIFESPAN,
-        )
-        self.refresh_lifespan = app.config.get(
+        ))
+        self.refresh_lifespan = pendulum.interval(**app.config.get(
             'JWT_REFRESH_LIFESPAN', DEFAULT_JWT_REFRESH_LIFESPAN,
-        )
+        ))
         self.header_name = app.config.get(
             'JWT_HEADER_NAME', DEFAULT_JWT_HEADER_NAME,
         )

--- a/flask_praetorian/constants.py
+++ b/flask_praetorian/constants.py
@@ -4,12 +4,13 @@ import enum
 
 DEFAULT_JWT_HEADER_NAME = 'Authorization'
 DEFAULT_JWT_HEADER_TYPE = 'Bearer'
-DEFAULT_JWT_ACCESS_LIFESPAN = pendulum.Interval(minutes=15)
-DEFAULT_JWT_REFRESH_LIFESPAN = pendulum.Interval(days=30)
+DEFAULT_JWT_ACCESS_LIFESPAN = dict(minutes=15)
+DEFAULT_JWT_REFRESH_LIFESPAN = dict(days=30)
 DEFAULT_JWT_ALGORITHM = 'HS256'
 DEFAULT_JWT_ALLOWED_ALGORITHMS = ['HS256']
 
-VITAM_AETERNUM = pendulum.Interval.max
+# 1M days seems reasonable. If this code is being used in 3000 years...welp
+VITAM_AETERNUM = pendulum.Interval(days=1000000)
 
 
 class AccessType(enum.Enum):


### PR DESCRIPTION
* Changed the code to expect a dictionary of initialization values for
  the LIFESPAN constants and configuration variables. This should allow
  a user to override the default settings in client configuration code
  by specifying a dictionary for the config setting (or json if you
  prefer to think about it that way) instead of an Interval value
* Fixed the VITAM_AETERNUM value and added unit tests to make sure it
  works this time