### PR TITLE
Issue #118: Added leading underscore to some methods

### DIFF
--- a/flask_praetorian/base.py
+++ b/flask_praetorian/base.py
@@ -89,7 +89,7 @@ class Praetorian:
             valid_schemes,
         )
 
-        self.user_class = self.validate_user_class(user_class)
+        self.user_class = self._validate_user_class(user_class)
         self.is_blacklisted = is_blacklisted or (lambda t: False)
 
         self.encode_key = app.config['SECRET_KEY']
@@ -135,7 +135,7 @@ class Praetorian:
         app.extensions['praetorian'] = self
 
     @classmethod
-    def validate_user_class(cls, user_class):
+    def _validate_user_class(cls, user_class):
         """
         Validates the supplied user_class to make sure that it has the
         class methods necessary to function correctly.
@@ -177,12 +177,12 @@ class Praetorian:
             'Could not find the requested user',
         )
         AuthenticationError.require_condition(
-            self.verify_password(password, user.password),
+            self._verify_password(password, user.password),
             'The password is incorrect',
         )
         return user
 
-    def verify_password(self, raw_password, hashed_password):
+    def _verify_password(self, raw_password, hashed_password):
         """
         Verifies that a plaintext password matches the hashed version of that
         password using the stored passlib password context
@@ -330,7 +330,7 @@ class Praetorian:
                 options={'verify_exp': False},
             )
 
-        self.validate_jwt_data(data, access_type=AccessType.refresh)
+        self._validate_jwt_data(data, access_type=AccessType.refresh)
 
         user = self.user_class.identify(data['id'])
         self._check_user(user)
@@ -369,10 +369,10 @@ class Praetorian:
                 algorithms=self.allowed_algorithms,
                 options={'verify_exp': False},
             )
-        self.validate_jwt_data(data, access_type=AccessType.access)
+        self._validate_jwt_data(data, access_type=AccessType.access)
         return data
 
-    def validate_jwt_data(self, data, access_type):
+    def _validate_jwt_data(self, data, access_type):
         """
         Validates that the data for a jwt token is valid
         """
@@ -412,7 +412,7 @@ class Praetorian:
                 'refresh permission for token has expired',
             )
 
-    def unpack_header(self, headers):
+    def _unpack_header(self, headers):
         """
         Unpacks a jwt token from a request header
         """
@@ -435,7 +435,7 @@ class Praetorian:
         """
         Unpacks a jwt token from the current flask request
         """
-        return self.unpack_header(flask.request.headers)
+        return self._unpack_header(flask.request.headers)
 
     def pack_header_for_user(
             self, user,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -54,20 +54,20 @@ class TestPraetorian:
         dumb_guard = Praetorian(app, user_class)
         assert dumb_guard.encrypt_password('some password') == 'some password'
 
-    def test_verify_password(self, app, user_class, default_guard):
+    def test__verify_password(self, app, user_class, default_guard):
         """
-        This test verifies that the verify_password function can be used to
+        This test verifies that the _verify_password function can be used to
         successfully compare a raw password against its hashed version
         """
         secret = default_guard.encrypt_password('some password')
-        assert default_guard.verify_password('some password', secret)
-        assert not default_guard.verify_password('not right', secret)
+        assert default_guard._verify_password('some password', secret)
+        assert not default_guard._verify_password('not right', secret)
 
         app.config['PRAETORIAN_HASH_SCHEME'] = 'pbkdf2_sha512'
         specified_guard = Praetorian(app, user_class)
         secret = specified_guard.encrypt_password('some password')
-        assert specified_guard.verify_password('some password', secret)
-        assert not specified_guard.verify_password('not right', secret)
+        assert specified_guard._verify_password('some password', secret)
+        assert not specified_guard._verify_password('not right', secret)
 
     def test_authenticate(self, app, user_class, db):
         """
@@ -91,27 +91,27 @@ class TestPraetorian:
         db.session.delete(the_dude)
         db.session.commit()
 
-    def test_validate_user_class(self, app, user_class):
+    def test__validate_user_class(self, app, user_class):
         """
-        This test verifies that the validate_user_class method properly
+        This test verifies that the _validate_user_class method properly
         checks the user_class that Praetorian will use for required attributes
         """
         with pytest.raises(PraetorianError) as err_info:
-            Praetorian.validate_user_class(NoLookupUser)
+            Praetorian._validate_user_class(NoLookupUser)
         assert "must have a lookup class method" in err_info.value.message
 
         with pytest.raises(PraetorianError) as err_info:
-            Praetorian.validate_user_class(NoIdentifyUser)
+            Praetorian._validate_user_class(NoIdentifyUser)
         assert "must have an identify class method" in err_info.value.message
 
-        assert Praetorian.validate_user_class(user_class)
+        assert Praetorian._validate_user_class(user_class)
 
-    def test_validate_jwt_data(self, app, user_class):
+    def test__validate_jwt_data(self, app, user_class):
         """
-        This test verifies that the validate_jwt_data method properly validates
-        the data for a jwt token. It checks that the proper exceptions are
-        raised when validation fails and that no exceptions are raised when
-        validation passes
+        This test verifies that the _validate_jwt_data method properly
+        validates the data for a jwt token. It checks that the proper
+        exceptions are raised when validation fails and that no exceptions are
+        raised when validation passes
         """
         guard = Praetorian(
             app, user_class,
@@ -119,21 +119,21 @@ class TestPraetorian:
         )
         data = dict()
         with pytest.raises(MissingClaimError) as err_info:
-            guard.validate_jwt_data(data, AccessType.access)
+            guard._validate_jwt_data(data, AccessType.access)
         assert 'missing jti' in str(err_info.value)
 
         data = dict(jti='blacklisted')
         with pytest.raises(BlacklistedError) as err_info:
-            guard.validate_jwt_data(data, AccessType.access)
+            guard._validate_jwt_data(data, AccessType.access)
 
         data = dict(jti='jti')
         with pytest.raises(MissingClaimError) as err_info:
-            guard.validate_jwt_data(data, AccessType.access)
+            guard._validate_jwt_data(data, AccessType.access)
         assert 'missing id' in str(err_info.value)
 
         data = dict(jti='jti', id=1)
         with pytest.raises(MissingClaimError) as err_info:
-            guard.validate_jwt_data(data, AccessType.access)
+            guard._validate_jwt_data(data, AccessType.access)
         assert 'missing exp' in str(err_info.value)
 
         data = dict(
@@ -142,7 +142,7 @@ class TestPraetorian:
             exp=pendulum.parse('2017-05-21 19:54:30').int_timestamp,
         )
         with pytest.raises(MissingClaimError) as err_info:
-            guard.validate_jwt_data(data, AccessType.access)
+            guard._validate_jwt_data(data, AccessType.access)
         assert 'missing rf_exp' in str(err_info.value)
 
         data = dict(
@@ -154,7 +154,7 @@ class TestPraetorian:
         moment = pendulum.parse('2017-05-21 19:54:32')
         with freezegun.freeze_time(moment):
             with pytest.raises(ExpiredAccessError) as err_info:
-                guard.validate_jwt_data(data, AccessType.access)
+                guard._validate_jwt_data(data, AccessType.access)
 
         data = dict(
             jti='jti',
@@ -165,7 +165,7 @@ class TestPraetorian:
         moment = pendulum.parse('2017-05-21 19:54:28')
         with freezegun.freeze_time(moment):
             with pytest.raises(EarlyRefreshError) as err_info:
-                guard.validate_jwt_data(data, AccessType.refresh)
+                guard._validate_jwt_data(data, AccessType.refresh)
 
         data = dict(
             jti='jti',
@@ -176,7 +176,7 @@ class TestPraetorian:
         moment = pendulum.parse('2017-05-21 20:54:32')
         with freezegun.freeze_time(moment):
             with pytest.raises(ExpiredRefreshError) as err_info:
-                guard.validate_jwt_data(data, AccessType.refresh)
+                guard._validate_jwt_data(data, AccessType.refresh)
 
         data = dict(
             jti='jti',
@@ -186,7 +186,7 @@ class TestPraetorian:
         )
         moment = pendulum.parse('2017-05-21 19:54:28')
         with freezegun.freeze_time(moment):
-            guard.validate_jwt_data(data, AccessType.access)
+            guard._validate_jwt_data(data, AccessType.access)
 
         data = dict(
             jti='jti',
@@ -196,7 +196,7 @@ class TestPraetorian:
         )
         moment = pendulum.parse('2017-05-21 19:54:32')
         with freezegun.freeze_time(moment):
-            guard.validate_jwt_data(data, AccessType.refresh)
+            guard._validate_jwt_data(data, AccessType.refresh)
 
     def test_encode_jwt_token(self, app, user_class, validating_user_class):
         """


### PR DESCRIPTION
Some of the methods should not be exposed in the API docs. These methods
had a leading underscore attached so that the API doc generator would
skip them