### PR TITLE
Issue #135: Made auth_required optional with other decorators

### DIFF
--- a/docs/tutorial_basic.rst
+++ b/docs/tutorial_basic.rst
@@ -112,12 +112,18 @@ Accessing an endpoint with required roles
 In addition to the ``@auth_required`` decorator, flask-praetorian also provides
 decorators that require users to have certain roles to access them.
 
+Each of the additional ``@roles_required`` and ``@roles_accepted`` decorators
+do not require the ``@auth_required`` decorator to be explicitly added. They
+will implicitly check ``@auth_required`` prior to checking the roles.
+However, explicitly adding an ``@auth_required`` decorator as well will not
+cause any issues (in fact, this was required in earlier versions).
+
 The ``@roles_required`` decorator keeps users that do not have all of the
 required roles from accessing the endpoint:
 
 .. literalinclude:: ../example/basic.py
    :language: python
-   :lines: 122-138
+   :lines: 122-137
    :caption: from `example/basic.py`_
 
 Let's try to access a protected endpoint with required roles.
@@ -156,7 +162,7 @@ of the listed roles:
 
 .. literalinclude:: ../example/basic.py
    :language: python
-   :lines: 141-158
+   :lines: 140-156
    :caption: from `example/basic.py`_
 
 The ``protected_operator_accepted`` endpoint accepts users that have either

--- a/example/basic.py
+++ b/example/basic.py
@@ -120,7 +120,6 @@ def protected():
 
 
 @app.route('/protected_admin_required')
-@flask_praetorian.auth_required
 @flask_praetorian.roles_required('admin')
 def protected_admin_required():
     """
@@ -139,7 +138,6 @@ def protected_admin_required():
 
 
 @app.route('/protected_operator_accepted')
-@flask_praetorian.auth_required
 @flask_praetorian.roles_accepted('operator', 'admin')
 def protected_operator_accepted():
     """

--- a/flask_praetorian/decorators.py
+++ b/flask_praetorian/decorators.py
@@ -5,45 +5,59 @@ from flask_praetorian.exceptions import MissingRoleError
 from flask_praetorian.utilities import (
     current_guard,
     add_jwt_data_to_app_context,
+    app_context_has_jwt_data,
     remove_jwt_data_from_app_context,
     current_rolenames,
 )
+
+
+def _verify_and_add_jwt():
+    """
+    This helper method just checks and adds jwt data to the app context. Will
+    not add jwt data if it is already present. Only use in this module
+    """
+    if not app_context_has_jwt_data():
+        guard = current_guard()
+        token = guard.read_token_from_header()
+        jwt_data = guard.extract_jwt_token(token)
+        add_jwt_data_to_app_context(jwt_data)
 
 
 def auth_required(method):
     """
     This decorator is used to ensure that a user is authenticated before
     being able to access a flask route. It also adds the current user to the
-    current flask context. This decorator should come first when using with
-    other flask_praetorian decorators.
+    current flask context.
     """
     @functools.wraps(method)
     def wrapper(*args, **kwargs):
-        guard = current_guard()
-        token = guard.read_token_from_header()
-        jwt_data = guard.extract_jwt_token(token)
-        add_jwt_data_to_app_context(jwt_data)
-        retval = method(*args, **kwargs)
-        remove_jwt_data_from_app_context()
-        return retval
+        _verify_and_add_jwt()
+        try:
+            return method(*args, **kwargs)
+        finally:
+            remove_jwt_data_from_app_context()
     return wrapper
 
 
 def roles_required(*required_rolenames):
     """
     This decorator ensures that any uses accessing the decorated route have all
-    the needed roles to access it. This decorator must follow the
-    @auth_required decorator.
+    the needed roles to access it. If an @auth_required decorator is not
+    supplied already, this decorator will implicitly check @auth_required first
     """
     def decorator(method):
         @functools.wraps(method)
         def wrapper(*args, **kwargs):
-            MissingRoleError.require_condition(
-                current_rolenames().issuperset(set(required_rolenames)),
-                "This endpoint requires all the following roles: {}",
-                [', '.join(required_rolenames)],
-            )
-            return method(*args, **kwargs)
+            _verify_and_add_jwt()
+            try:
+                MissingRoleError.require_condition(
+                    current_rolenames().issuperset(set(required_rolenames)),
+                    "This endpoint requires all the following roles: {}",
+                    [', '.join(required_rolenames)],
+                )
+                return method(*args, **kwargs)
+            finally:
+                remove_jwt_data_from_app_context()
         return wrapper
     return decorator
 
@@ -51,17 +65,23 @@ def roles_required(*required_rolenames):
 def roles_accepted(*accepted_rolenames):
     """
     This decorator ensures that any uses accessing the decorated route have one
-    of the needed roles to access it. This decorator must follow the
-    @auth_required decorator.
+    of the needed roles to access it. If an @auth_required decorator is not
+    supplied already, this decorator will implicitly check @auth_required first
     """
     def decorator(method):
         @functools.wraps(method)
         def wrapper(*args, **kwargs):
-            MissingRoleError.require_condition(
-                not current_rolenames().isdisjoint(set(accepted_rolenames)),
-                "This endpoint requires one of the following roles: {}",
-                [', '.join(accepted_rolenames)],
-            )
-            return method(*args, **kwargs)
+            _verify_and_add_jwt()
+            try:
+                MissingRoleError.require_condition(
+                    not current_rolenames().isdisjoint(
+                        set(accepted_rolenames)
+                    ),
+                    "This endpoint requires one of the following roles: {}",
+                    [', '.join(accepted_rolenames)],
+                )
+                return method(*args, **kwargs)
+            finally:
+                remove_jwt_data_from_app_context()
         return wrapper
     return decorator

--- a/flask_praetorian/utilities.py
+++ b/flask_praetorian/utilities.py
@@ -16,6 +16,13 @@ def current_guard():
     return guard
 
 
+def app_context_has_jwt_data():
+    """
+    Checks if there is already jwt_data added to the app context
+    """
+    return hasattr(flask._app_ctx_stack.top, 'jwt_data')
+
+
 def add_jwt_data_to_app_context(jwt_data):
     """
     Adds a dictionary of jwt data (presumably unpacked from a token) to the
@@ -46,7 +53,8 @@ def remove_jwt_data_from_app_context():
     Removes the dict of jwt token data from the top of the flask app's context
     """
     ctx = flask._app_ctx_stack.top
-    del ctx.jwt_data
+    if app_context_has_jwt_data():
+        del ctx.jwt_data
 
 
 def current_user_id():

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -110,8 +110,8 @@ class TestPraetorianDecorators:
         to ensure that any users attempting to access a given endpoint must
         have all of the roles listed. If the correct roles are not supplied,
         a 401 error occurs with an informative error message.  This
-        test also verifies that the @roles_required decorator has to be used
-        with the @auth_required decorator
+        test also verifies that the @roles_required can be used with or without
+        an explicit @auth_required decorator
         """
 
         # Lacks one of one required roles
@@ -155,21 +155,19 @@ class TestPraetorianDecorators:
             '/undecorated_admin_required',
             headers=default_guard.pack_header_for_user(self.maude),
         )
-        assert response.status_code == 401
-        assert (
-            "No jwt_data found in app context"
-            in response.json['message']
+        assert response.status_code == 200
+
+        response = client.get(
+            '/undecorated_admin_accepted',
+            headers=default_guard.pack_header_for_user(self.maude),
         )
+        assert response.status_code == 200
 
         response = client.get(
             '/reversed_decorators',
-            headers=default_guard.pack_header_for_user(self.walter),
+            headers=default_guard.pack_header_for_user(self.maude),
         )
-        assert response.status_code == 401
-        assert (
-            "No jwt_data found in app context"
-            in response.json['message']
-        )
+        assert response.status_code == 200
 
     def test_roles_accepted(self, client, default_guard):
         """

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,7 +1,10 @@
+import flask
 import pytest
 
 from flask_praetorian.utilities import (
     add_jwt_data_to_app_context,
+    app_context_has_jwt_data,
+    remove_jwt_data_from_app_context,
     current_user,
     current_user_id,
     current_rolenames,
@@ -10,6 +13,30 @@ from flask_praetorian.exceptions import PraetorianError
 
 
 class TestPraetorianUtilities:
+
+    def test_app_context_has_jwt_data(self):
+        """
+        This test verifies that the app_context_has_jwt_data method can
+        determine if jwt_data has been added to the app context yet
+        """
+        assert not app_context_has_jwt_data()
+        add_jwt_data_to_app_context({'a': 1})
+        assert app_context_has_jwt_data()
+        remove_jwt_data_from_app_context()
+        assert not app_context_has_jwt_data()
+
+    def test_remove_jwt_data_from_app_context(self):
+        """
+        This test verifies that jwt data can be removed from an app context.
+        It also verifies that attempting to remove the data if it does not
+        exist there does not cause an exception
+        """
+        jwt_data = {'a': 1}
+        add_jwt_data_to_app_context(jwt_data)
+        assert flask._app_ctx_stack.top.jwt_data == jwt_data
+        remove_jwt_data_from_app_context()
+        assert not hasattr(flask._app_ctx_stack.top, 'jwt_data')
+        remove_jwt_data_from_app_context()
 
     def test_current_user_id(self, user_class, db, default_guard):
         """


### PR DESCRIPTION
It used to be that you had to explicitly declare 'auth_required' when
using the other decorators. The order was also important. This was
unnecessarily cumbersome, and it was confusing when declaring dynamic
routes with flask_restplus as you need to add decorators in a list. The
order of said list had to be reverse of how they are specified as
decorators in statically declared routes.

The easiest fix for this was to have the decorators implicitly check for
athorization themselves if the app context didn't already have jwt data.

The result of this is that you may or may not include an explicit
@auth_required when you are using one of the other decorators.