### PR TITLE
Optional auth

### DIFF
--- a/flask_praetorian/__init__.py
+++ b/flask_praetorian/__init__.py
@@ -6,6 +6,7 @@ from flask_praetorian.base import Praetorian  # noqa
 from flask_praetorian.exceptions import PraetorianError  # noqa
 from flask_praetorian.decorators import (  # noqa
     auth_required,
+    auth_accepted,
     roles_required,
     roles_accepted,
 )

--- a/flask_praetorian/constants.py
+++ b/flask_praetorian/constants.py
@@ -21,6 +21,15 @@ DEFAULT_CONFIRMATION_TEMPLATE = (
 DEFAULT_CONFIRMATION_SENDER = 'you@whatever.com'
 DEFAULT_CONFIRMATION_SUBJECT = 'Please confirm your registration'
 
+DEFAULT_RESET_TEMPLATE = (
+    "{}/flask_praetorian/templates/reset_email.html".format(
+        dirname(dirname(abspath(__file__))),
+    )
+)
+
+DEFAULT_RESET_SENDER = 'you@whatever.com'
+DEFAULT_RESET_SUBJECT = 'Password Reset Requested'
+
 DEFAULT_HASH_AUTOUPDATE = False
 DEFAULT_HASH_AUTOTEST = False
 DEFAULT_HASH_SCHEME = 'pbkdf2_sha512'
@@ -32,10 +41,12 @@ DEFAULT_HASH_DEPRECATED_SCHEMES = []
 
 REFRESH_EXPIRATION_CLAIM = 'rf_exp'
 IS_REGISTRATION_TOKEN_CLAIM = 'is_ert'
+IS_RESET_TOKEN_CLAIM = 'is_ert'
 RESERVED_CLAIMS = {
     'iat', 'exp', 'jti', 'id', 'rls',
     REFRESH_EXPIRATION_CLAIM,
     IS_REGISTRATION_TOKEN_CLAIM,
+    IS_RESET_TOKEN_CLAIM,
 }
 
 # 1M days seems reasonable. If this code is being used in 3000 years...welp
@@ -46,3 +57,4 @@ class AccessType(enum.Enum):
     access = 'ACCESS'
     refresh = 'REFRESH'
     register = 'REGISTER'
+    reset = 'RESET'

--- a/flask_praetorian/decorators.py
+++ b/flask_praetorian/decorators.py
@@ -12,16 +12,20 @@ from flask_praetorian.utilities import (
 )
 
 
-def _verify_and_add_jwt():
+def _verify_and_add_jwt(optional=False):
     """
     This helper method just checks and adds jwt data to the app context. Will
     not add jwt data if it is already present. Only use in this module
     """
     if not app_context_has_jwt_data():
         guard = current_guard()
-        token = guard.read_token_from_header()
-        jwt_data = guard.extract_jwt_token(token)
-        add_jwt_data_to_app_context(jwt_data)
+        try:
+            token = guard.read_token_from_header()
+            jwt_data = guard.extract_jwt_token(token)
+            add_jwt_data_to_app_context(jwt_data)
+        except Exception as e:
+            if not optional:
+                raise e
 
 
 def auth_required(method):
@@ -37,6 +41,26 @@ def auth_required(method):
             return method(*args, **kwargs)
         finally:
             remove_jwt_data_from_app_context()
+    return wrapper
+
+
+def auth_accepted(method):
+    """
+    This decorator is used to allow an authenticated user to be identified
+    while being able to access a flask route, and adds the current user to the
+    current flask context.
+    """
+    @functools.wraps(method)
+    def wrapper(*args, **kwargs):
+        print(".....1")
+        _verify_and_add_jwt(optional=True)
+        print(".....2")
+        try:
+            return method(*args, **kwargs)
+        finally:
+            print(".....3")
+            remove_jwt_data_from_app_context()
+            print(".....4")
     return wrapper
 
 

--- a/flask_praetorian/exceptions.py
+++ b/flask_praetorian/exceptions.py
@@ -100,6 +100,13 @@ class LegacyScheme(PraetorianError):
     pass
 
 
+class InvalidResetToken(PraetorianError):
+    """
+    The supplied registration token is invalid
+    """
+    pass
+
+
 class InvalidRegistrationToken(PraetorianError):
     """
     The supplied registration token is invalid

--- a/flask_praetorian/templates/reset_email.html
+++ b/flask_praetorian/templates/reset_email.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Simple Transactional Email</title>
+    <style>
+    /* -------------------------------------
+        INLINED WITH htmlemail.io/inline
+    ------------------------------------- */
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+            table[class=body] ul,
+            table[class=body] ol,
+            table[class=body] td,
+            table[class=body] span,
+            table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+            table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+    }
+
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+            .ExternalClass p,
+            .ExternalClass span,
+            .ExternalClass font,
+            .ExternalClass td,
+            .ExternalClass div {
+        line-height: 100%;
+      }
+      .apple-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      .btn-primary table td:hover {
+        background-color: #34495e !important;
+      }
+      .btn-primary a:hover {
+        background-color: #34495e !important;
+        border-color: #34495e !important;
+      }
+    }
+    </style>
+  </head>
+  <body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
+      <tr>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 580px; padding: 10px; width: 580px;">
+          <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 580px; padding: 10px;">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">This is preheader text. Some clients will show this text as a preview.</span>
+            <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 3px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                    <tr>
+                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Hi there</p>
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top; background-color: #3498db; border-radius: 5px; text-align: center;"> <a href="{{confirmation_uri}}?token={{ token }}" target="_blank" style="display: inline-block; color: #ffffff; background-color: #3498db; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: #3498db;">Password Reset Token {{ token }}</a> </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Please use the time expiring info above to finish your password reset process.</p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,15 @@ def app(tmpdir_factory):
     def unprotected():
         return jsonify(message='success')
 
+    @app.route('/kinda_protected')
+    @flask_praetorian.auth_accepted
+    def kinda_protected():
+        try:
+            authed_user = flask_praetorian.current_user().username
+        except Exception as e:  # noqa: F841
+            authed_user = None
+        return jsonify(message='success', user=authed_user)
+
     @app.route('/protected')
     @flask_praetorian.auth_required
     def protected():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ class User(_db.Model):
     password = _db.Column(_db.Text)
     email = _db.Column(_db.Text)
     roles = _db.Column(_db.Text)
+    active_reset = _db.Column(_db.Text)
 
     @property
     def rolenames(self):


### PR DESCRIPTION
Added an `auth_accepted` decorator.

When used, the presence of a valid token will be processed, and the `current_user()` details will be present.  When not provided, no processing is done, and no errors are produced.