### PR TITLE
Call hook functions when jwts are generated, within encode_jwt_t…

### DIFF
--- a/flask_praetorian/base.py
+++ b/flask_praetorian/base.py
@@ -7,7 +7,6 @@ import re
 import textwrap
 import uuid
 import warnings
-import copy
 
 from flask_mail import Message
 
@@ -71,12 +70,12 @@ class Praetorian:
     """
 
     def __init__(
-                self,
-                app=None,
-                user_class=None,
-                is_blacklisted=None,
-                encode_jwt_token_hook=None,
-                refresh_jwt_token_hook=None
+            self,
+            app=None,
+            user_class=None,
+            is_blacklisted=None,
+            encode_jwt_token_hook=None,
+            refresh_jwt_token_hook=None,
     ):
         self.pwd_ctx = None
         self.hash_scheme = None
@@ -84,20 +83,20 @@ class Praetorian:
 
         if app is not None and user_class is not None:
             self.init_app(
-                        app,
-                        user_class,
-                        is_blacklisted,
-                        encode_jwt_token_hook,
-                        refresh_jwt_token_hook
+                app,
+                user_class,
+                is_blacklisted,
+                encode_jwt_token_hook,
+                refresh_jwt_token_hook,
             )
 
     def init_app(
-                self,
-                app=None,
-                user_class=None,
-                is_blacklisted=None,
-                encode_jwt_token_hook=None,
-                refresh_jwt_token_hook=None
+            self,
+            app=None,
+            user_class=None,
+            is_blacklisted=None,
+            encode_jwt_token_hook=None,
+            refresh_jwt_token_hook=None,
     ):
         """
         Initializes the Praetorian extension
@@ -450,7 +449,7 @@ class Praetorian:
         payload_parts.update(custom_claims)
 
         if self.encode_jwt_token_hook:
-            self.encode_jwt_token_hook(copy.deepcopy(payload_parts))
+            self.encode_jwt_token_hook(**payload_parts)
         return jwt.encode(
             payload_parts, self.encode_key, self.encode_algorithm,
         ).decode('utf-8')
@@ -518,7 +517,7 @@ class Praetorian:
         payload_parts.update(custom_claims)
 
         if self.refresh_jwt_token_hook:
-            self.refresh_jwt_token_hook(copy.deepcopy(payload_parts))
+            self.refresh_jwt_token_hook(**payload_parts)
         return jwt.encode(
             payload_parts, self.encode_key, self.encode_algorithm,
         ).decode('utf-8')

--- a/flask_praetorian/base.py
+++ b/flask_praetorian/base.py
@@ -70,33 +70,60 @@ class Praetorian:
     for applications and designated endpoints
     """
 
-    def __init__(self, app=None, user_class=None, is_blacklisted=None, encode_jwt_token_hook=None, refresh_jwt_token_hook=None):
+    def __init__(
+                self,
+                app=None,
+                user_class=None,
+                is_blacklisted=None,
+                encode_jwt_token_hook=None,
+                refresh_jwt_token_hook=None
+    ):
         self.pwd_ctx = None
         self.hash_scheme = None
         self.salt = None
 
         if app is not None and user_class is not None:
-            self.init_app(app, user_class, is_blacklisted, encode_jwt_token_hook, refresh_jwt_token_hook)
+            self.init_app(
+                        app,
+                        user_class,
+                        is_blacklisted,
+                        encode_jwt_token_hook,
+                        refresh_jwt_token_hook
+            )
 
-    def init_app(self, app, user_class, is_blacklisted=None, encode_jwt_token_hook=None, refresh_jwt_token_hook=None):
+    def init_app(
+                self,
+                app=None,
+                user_class=None,
+                is_blacklisted=None,
+                encode_jwt_token_hook=None,
+                refresh_jwt_token_hook=None
+    ):
         """
         Initializes the Praetorian extension
 
-        :param: app:                    The flask app to bind this extension to
-        :param: user_class:             The class used to interact with user data
-        :param: is_blacklisted:         A method that may optionally be used to
-                                        check the token against a blacklist when
-                                        access or refresh is requested
-                                        Should take the jti for the token to check
-                                        as a single argument. Returns True if
-                                        the jti is blacklisted, False otherwise.
-                                        By default, always returns False.
-        :param encode_jwt_token_hook:   A method that may optionally be called before
-                                        an encoded jwt is generated. Should take payload_parts
-                                        which contains the ingredients for the jwt.
-        :param refresh_jwt_token_hook:  A method that may optionally be called before
-                                        an encoded jwt is refreshed. Should take payload_parts
-                                        which contains the ingredients for the jwt.
+        :param: app:                    The flask app to bind this
+                                        extension to
+        :param: user_class:             The class used to interact with
+                                        user data
+        :param: is_blacklisted:         A method that may optionally be
+                                        used to check the token against
+                                        a blacklist when access or refresh
+                                        is requested should take the jti
+                                        for the token to check as a single
+                                        argument. Returns True if the jti is
+                                        blacklisted, False otherwise. By
+                                        default, always returns False.
+        :param encode_jwt_token_hook:   A method that may optionally be
+                                        called right before an encoded jwt
+                                        is generated. Should take
+                                        payload_parts which contains the
+                                        ingredients for the jwt.
+        :param refresh_jwt_token_hook:  A method that may optionally be called
+                                        right before an encoded jwt is
+                                        refreshed. Should take payload_parts
+                                        which contains the ingredients for
+                                        the jwt.
         """
         PraetorianError.require_condition(
             app.config.get('SECRET_KEY') is not None,

--- a/flask_praetorian/base.py
+++ b/flask_praetorian/base.py
@@ -7,6 +7,7 @@ import re
 import textwrap
 import uuid
 import warnings
+import copy
 
 from flask_mail import Message
 
@@ -69,27 +70,33 @@ class Praetorian:
     for applications and designated endpoints
     """
 
-    def __init__(self, app=None, user_class=None, is_blacklisted=None):
+    def __init__(self, app=None, user_class=None, is_blacklisted=None, encode_jwt_token_hook=None, refresh_jwt_token_hook=None):
         self.pwd_ctx = None
         self.hash_scheme = None
         self.salt = None
 
         if app is not None and user_class is not None:
-            self.init_app(app, user_class, is_blacklisted)
+            self.init_app(app, user_class, is_blacklisted, encode_jwt_token_hook, refresh_jwt_token_hook)
 
-    def init_app(self, app, user_class, is_blacklisted=None):
+    def init_app(self, app, user_class, is_blacklisted=None, encode_jwt_token_hook=None, refresh_jwt_token_hook=None):
         """
         Initializes the Praetorian extension
 
-        :param: app:            The flask app to bind this extension to
-        :param: user_class:     The class used to interact with user data
-        :param: is_blacklisted: A method that may optionally be used to
-                                check the token against a blacklist when
-                                access or refresh is requested
-                                Should take the jti for the token to check
-                                as a single argument. Returns True if
-                                the jti is blacklisted, False otherwise.
-                                By default, always returns False.
+        :param: app:                    The flask app to bind this extension to
+        :param: user_class:             The class used to interact with user data
+        :param: is_blacklisted:         A method that may optionally be used to
+                                        check the token against a blacklist when
+                                        access or refresh is requested
+                                        Should take the jti for the token to check
+                                        as a single argument. Returns True if
+                                        the jti is blacklisted, False otherwise.
+                                        By default, always returns False.
+        :param encode_jwt_token_hook:   A method that may optionally be called before
+                                        an encoded jwt is generated. Should take payload_parts
+                                        which contains the ingredients for the jwt.
+        :param refresh_jwt_token_hook:  A method that may optionally be called before
+                                        an encoded jwt is refreshed. Should take payload_parts
+                                        which contains the ingredients for the jwt.
         """
         PraetorianError.require_condition(
             app.config.get('SECRET_KEY') is not None,
@@ -125,6 +132,8 @@ class Praetorian:
 
         self.user_class = self._validate_user_class(user_class)
         self.is_blacklisted = is_blacklisted or (lambda t: False)
+        self.encode_jwt_token_hook = encode_jwt_token_hook
+        self.refresh_jwt_token_hook = refresh_jwt_token_hook
 
         self.encode_key = app.config['SECRET_KEY']
         self.allowed_algorithms = app.config.get(
@@ -412,6 +421,9 @@ class Praetorian:
             "Attaching custom claims: {}".format(custom_claims),
         )
         payload_parts.update(custom_claims)
+
+        if self.encode_jwt_token_hook:
+            self.encode_jwt_token_hook(copy.deepcopy(payload_parts))
         return jwt.encode(
             payload_parts, self.encode_key, self.encode_algorithm,
         ).decode('utf-8')
@@ -477,6 +489,9 @@ class Praetorian:
             REFRESH_EXPIRATION_CLAIM: refresh_expiration,
         }
         payload_parts.update(custom_claims)
+
+        if self.refresh_jwt_token_hook:
+            self.refresh_jwt_token_hook(copy.deepcopy(payload_parts))
         return jwt.encode(
             payload_parts, self.encode_key, self.encode_algorithm,
         ).decode('utf-8')


### PR DESCRIPTION
I would like to record all jwts issued by my flask app. There are currently 2 actions that make it difficult to achieve this:`send_registration_email` and `send_reset_email` as they generate the token and automatically send it via email without returning them in my app. 

Furthermore, given my objective to record every token that gets generated (into a database or other persistent datastore), it makes more sense to save payload parts rather than the encoded jwt. See [flask-jwt-extended db blacklist example](https://github.com/vimalloc/flask-jwt-extended/tree/master/examples/database_blacklist) for a sample approach/ db schema. Currently in flask-praetorian (ignoring the aforementioned cases when the access tokens are not returned in the app) after encoding a token I would have to subsequently decode the token before calling a function to write the data to the db. To make this process easier and efficient, hook functions can guarantee that in all cases of token creation and refresh I am able to reliably maintain my datastore.