### PR TITLE
Poetry error - copyright property invalid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.poetry]
 name = "flask-praetorian"
 version = "1.0.0"
-copyright = 2017
 description = "Strong, Simple, and Precise security for Flask APIs (using jwt)"
 authors = ["Tucker Beck <tucker.beck@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
When trying to build from master, I came across an error - ("The Poetry configuration is invalid:\\n" + message)\n  ... The Poetry configuration is invalid:\n    - Additional properties are not allowed (\'copyright\' was unexpected).

Reading through the [documentation](https://python-poetry.org/docs/pyproject/) it looks like copyright is not a valid section.

Removed it from the toml file