### PR TITLE
fix python version usage / use poetry 1.1.11 for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python_version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version }}
     - name: get-poetry
-      run: pip install poetry==1.1.6
+      run: pip install poetry==1.1.11
     - name: install
       run: poetry install
     - name: test


### PR DESCRIPTION
The CI tests fail because the python version isn't set correctly. Because it is not set correctly python 3.10 will be used which causes poetry 1.1.6 to fail. Poetry 1.1.11 has python 3.10 compatability but other package dependencies (such as cffi) need to be upgraded to work with python 3.10. These updates will allow the dependencies to be installed but the tests will fail, but I couldn't make out why at this point.