### PR TITLE
added support to unpack jwt token from post param

### DIFF
--- a/flask_praetorian/constants.py
+++ b/flask_praetorian/constants.py
@@ -3,9 +3,10 @@ import enum
 from os.path import dirname, abspath
 
 
-DEFAULT_JWT_PLACES = ["header", "cookie"]
+DEFAULT_JWT_PLACES = ["header", "cookie", "post_param"]
 DEFAULT_JWT_COOKIE_NAME = "access_token"
 DEFAULT_JWT_HEADER_NAME = "Authorization"
+DEFAULT_JWT_POST_PARAM_NAME = "jwtToken"
 DEFAULT_JWT_HEADER_TYPE = "Bearer"
 DEFAULT_JWT_ACCESS_LIFESPAN = pendulum.duration(minutes=15)
 DEFAULT_JWT_REFRESH_LIFESPAN = pendulum.duration(days=30)


### PR DESCRIPTION
please see https://stackoverflow.com/a/59363326 for why this is needed.

(more details:)
First of all thanks for this great & working package!
Secondly I wanted to download a file from my flask backend, but make sure only authenticated users could download.
Using flask-praetorian to secure the file download endpoint was my first decision, and after failing to download the file from within the react frontend (i.e. using axios & js-file-download), I found I could easily use window.open with a post request to download files with my token as a post param (from react's localStorage) (please see stackoverflow question and comment linked), but it would require a (small) change (thanks to the quality design of this framework!). I have implemented and tested this approach in my code and it works... Please to pull this so others could benefit more easily and I will enhance the original stackoverflow answer to benefit everyone.

Thanks,
Shai