### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,7 +77,7 @@ Code contributions should follow best-practices where possible. Use the
 `Zen of Python <https://www.python.org/dev/peps/pep-0020/>`_ as a guideline.
 All code must stick to pep8 style guidelines.
 
-Adding addtional dependencies should be limited except where needed
+Adding additional dependencies should be limited except where needed
 functionality can be easily added through pip packages. Please include
 dependencies that are only applicable to development and testing in the
 dev dependency list. Packages should only be added to the dependency lists if::

--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -22,7 +22,7 @@ flask-jwt
 
 The `flask-jwt <https://github.com/mattupstate/flask-jwt>`_ extension was one of
 the original jwt based flask security extensions. It was a mostly fully featured
-securtiy package, and it was highly opinionated. This was the package that the
+security package, and it was highly opinionated. This was the package that the
 precursor to flask-praetorian sought to use. However functionality was limited,
 and while a solution to one particular issue was being pursued, it became
 apparent that flask-jwt had been abandoned.
@@ -95,7 +95,7 @@ This package was the original inspiration for flask-praetorian. It is a fully-
 featured security extension for flask and offers some of the same features as
 flask-praetorian like password verification, role based access, and others.
 However, this extension is meant to be used for flask websites and includes
-wtform components and other things that are not neeeded for flask-based APIs.
+wtform components and other things that are not needed for flask-based APIs.
 Including all the extra stuff is both cumbersome and unnecessary in an API.
 The flask-praetorian extension intends to be a similar batteries-included
 package while offering a simple API with a full set of security tools.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -77,7 +77,7 @@ Code contributions should follow best-practices where possible. Use the
 `Zen of Python <https://www.python.org/dev/peps/pep-0020/>`_ as a guideline.
 All code must stick to pep8 style guidelines.
 
-Adding addtional dependencies should be limited except where needed
+Adding additional dependencies should be limited except where needed
 functionality can be easily added through pip packages. Please include
 dependencies that are only applicable to development and testing in the
 dev dependency list. Packages should only be added to the dependency lists if::

--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -15,7 +15,7 @@ fixed amount of time, the database is re-checked to make sure that a user is sti
 allowed access.
 
 At that point in time, a new token is issued with the same claims as the first except
-its refresh lifespan is not extened. This is so that a token cannot be refreshed in
+its refresh lifespan is not extended. This is so that a token cannot be refreshed in
 perpetuity.
 
 Once a token's access lifespan and refresh lifespan are both expired, the user must
@@ -25,7 +25,7 @@ Rate Limiting
 -------------
 
 There is not any sort of rate-limiting protection offered by flask-praetorian.
-Thus, if your app does not implment such a thing, it could be vulnerable to brute
+Thus, if your app does not implement such a thing, it could be vulnerable to brute
 force attacks. It's advisable that you implement some sort of system for limiting
 incorrect username/password attempts.
 

--- a/example/refresh.py
+++ b/example/refresh.py
@@ -106,7 +106,7 @@ def login():
 def refresh():
     """
     Refreshes an existing JWT by creating a new one that is a copy of the old
-    except that it has a refrehsed access expiration.
+    except that it has a refreshed access expiration.
     .. example::
        $ curl http://localhost:5000/refresh -X GET \
          -H "Authorization: Bearer <your_token>"

--- a/flask_praetorian/base.py
+++ b/flask_praetorian/base.py
@@ -461,7 +461,7 @@ class Praetorian:
         :param: override_access_lifespan:  Override's the instance's access
                                            lifespan to set a custom duration
                                            after which the new token's
-                                           accessability will expire. May not
+                                           accessibility will expire. May not
                                            exceed the refresh_lifespan
         :param: override_refresh_lifespan: Override's the instance's refresh
                                            lifespan to set a custom duration
@@ -557,7 +557,7 @@ class Praetorian:
         :param: override_access_lifespan:  Override's the instance's access
                                            lifespan to set a custom duration
                                            after which the new token's
-                                           accessability will expire. May not
+                                           accessibility will expire. May not
                                            exceed the refresh lifespan
         """
         moment = pendulum.now("UTC")
@@ -792,7 +792,7 @@ class Praetorian:
         :param: override_access_lifespan:  Override's the instance's access
                                            lifespan to set a custom duration
                                            after which the new token's
-                                           accessability will expire. May not
+                                           accessibility will expire. May not
                                            exceed the refresh_lifespan
         :param: override_refresh_lifespan: Override's the instance's refresh
                                            lifespan to set a custom duration
@@ -1106,7 +1106,7 @@ class Praetorian:
         Validate a password hash contained in the user object is
              hashed with the defined hash scheme (PRAETORIAN_HASH_SCHEME).
         If not, raise an Exception of `LegacySchema`, unless the
-             `password` arguement is provided, in which case an attempt
+             `password` argument is provided, in which case an attempt
              to call `user.save()` will be made, updating the hashed
              password to the currently desired hash scheme
              (PRAETORIAN_HASH_SCHEME).


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.rst
- docs/comparison.rst
- docs/contributing.rst
- docs/notes.rst
- example/refresh.py
- flask_praetorian/base.py

Fixes:
- Should read `accessibility` rather than `accessability`.
- Should read `additional` rather than `addtional`.
- Should read `security` rather than `securtiy`.
- Should read `refreshed` rather than `refrehsed`.
- Should read `needed` rather than `neeeded`.
- Should read `implement` rather than `implment`.
- Should read `extended` rather than `extened`.
- Should read `argument` rather than `arguement`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md