### PR TITLE
include flask 3.0; exclude flask 1.0 versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pendulum = "^2.1"
 passlib = "^1.7"
 flask-buzz = "^2.0"
 flask-mail = "^0.9.1"
-flask = ">=1.0, <3.0"
+flask = ">=2.0, <4.0"
 
 [tool.poetry.group.dev.dependencies]
 flask-sqlalchemy = "^3.1"


### PR DESCRIPTION
This library is currently locked to Flask 2.0 max, but 3.0 is out already. I think at this point it also would make sense to remove support for Flask 1 versions.