### PR TITLE
Issue #315: Added support for UUID primary keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased
 ----------
 
+v1.6.2 - 2024-10-25
+-------------------
+- Added support for UUIDs in the ``id`` field.
+
+Note:
+-----
+I accidently published v1.6.1 last time, so there's a jump in the version numbers here
+
 v1.5.1 - 2024-10-25
 -------------------
 - Updated dependencies in poetry.lock to shut up dependabot.

--- a/flask_praetorian/base.py
+++ b/flask_praetorian/base.py
@@ -12,7 +12,7 @@ from flask_mailman import EmailMessage
 
 from passlib.context import CryptContext
 
-from flask_praetorian.utilities import deprecated, duration_from_string
+from flask_praetorian.utilities import deprecated, duration_from_string, is_jsonable
 
 from flask_praetorian.exceptions import (
     AuthenticationError,
@@ -511,7 +511,7 @@ class Praetorian:
             "iat": moment.int_timestamp,
             "exp": access_expiration,
             "jti": str(uuid.uuid4()),
-            "id": user.identity,
+            "id": user.identity if is_jsonable(user.identity) else str(user.identity),
             "rls": ",".join(user.rolenames),
             REFRESH_EXPIRATION_CLAIM: refresh_expiration,
         }

--- a/flask_praetorian/utilities.py
+++ b/flask_praetorian/utilities.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import json
 import re
 import warnings
 
@@ -149,6 +150,17 @@ def current_custom_claims():
     """
     jwt_data = get_jwt_data_from_app_context()
     return {k: v for (k, v) in jwt_data.items() if k not in RESERVED_CLAIMS}
+
+
+def is_jsonable(instance):
+    """
+    This method checks if an instance is JSON serializable.
+    """
+    try:
+        json.dumps(instance)
+        return True
+    except Exception:
+        return False
 
 
 def deprecated(reason):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,10 +1,13 @@
 import flask
 import pendulum
 import pytest
+from datetime import datetime
+from uuid import uuid4
 
 from flask_praetorian.utilities import (
     add_jwt_data_to_app_context,
     app_context_has_jwt_data,
+    is_jsonable,
     remove_jwt_data_from_app_context,
     current_user,
     current_user_id,
@@ -151,3 +154,19 @@ class TestPraetorianUtilities:
             duration_from_string("12x1y1z")
         with pytest.raises(ConfigurationError):
             duration_from_string("")
+
+    def test_is_jsonable(self):
+        """
+        This test verifies that the is_jsonable method returns True for
+        json-serializable objects and False for non-serializable ones
+        """
+        assert is_jsonable(False)
+        assert is_jsonable(1)
+        assert is_jsonable(2.0)
+        assert is_jsonable("")
+        assert is_jsonable([])
+        assert is_jsonable({})
+        assert is_jsonable(None)
+        assert not is_jsonable(set({}))
+        assert not is_jsonable(datetime.now())
+        assert not is_jsonable(uuid4())


### PR DESCRIPTION
Updated the `encode_jwt_token()` method so that it can use non-JSON serializable `id` fields from the user class. This includes UUID primary keys. If the `id` field is JSON serializable, it will be serialized as-is. If it is not JSON serializable, it will be converted to a string first.